### PR TITLE
Add multi-row header support

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ jscad-electronics includes models for various components, including:
 - ICs (DIP, SOIC, TSSOP, QFN, QFP, BGA)
 - Diodes (SOD-123)
 - Transistors (SOT-23, SOT-563, SOT-723)
+- Multi-row pin headers
 - And more!
 
 Check the `lib` directory for a full list of available components.
@@ -67,6 +68,7 @@ Most components accept parameters for customization. For example:
 
 ```jsx
 <QFN fullWidth={4} height={0.8} thermalPadSize={2} />
+<PinRow numberOfPins={6} rows={2} />
 ```
 
 Refer to the individual component files for available customization options.

--- a/examples/footprinter3d/fp-pinrow6-rows2.example.tsx
+++ b/examples/footprinter3d/fp-pinrow6-rows2.example.tsx
@@ -1,0 +1,13 @@
+import { JsCadView } from "jscad-fiber"
+import { Footprinter3d } from "lib/Footprinter3d"
+import { ExtrudedPads } from "lib/ExtrudedPads"
+
+const footprint = "pinrow6_rows2_id01mm_p2.54mm_od01.6mm"
+export default () => {
+  return (
+    <JsCadView zAxisUp showGrid>
+      <Footprinter3d footprint={footprint} />
+      <ExtrudedPads footprint={footprint} />
+    </JsCadView>
+  )
+}

--- a/lib/FemaleHeader.tsx
+++ b/lib/FemaleHeader.tsx
@@ -6,41 +6,94 @@ export const FemaleHeader = ({
   legsLength = 3,
   outerDiameter = 0.945,
   innerDiameter = 0.945,
+  rows = 1,
 }: {
   numberOfPins: number
   pitch?: number
   legsLength?: number
   outerDiameter?: number
   innerDiameter?: number
+  rows?: number
 }) => {
   const pinThickness = innerDiameter / 1.5
-  const bodyDepth = pinThickness * 2 + outerDiameter
+  const numPinsPerRow = Math.ceil(numberOfPins / rows)
+  const bodyDepth = (rows - 1) * pitch + pinThickness * 2 + outerDiameter
   const bodyHeight = 5
-  const bodyWidth = (numberOfPins - 1) * pitch + outerDiameter + pitch / 2
+  const bodyWidth = (numPinsPerRow - 1) * pitch + outerDiameter + pitch / 2
   const gapWidth = pinThickness * 1.6
-  const xoff = -((numberOfPins - 1) / 2) * pitch
+  const xStart = -((numPinsPerRow - 1) / 2) * pitch
+  const ySpacing = -pitch
+
+  const positions: [number, number][] = []
+
+  if (rows === 1) {
+    for (let i = 0; i < numberOfPins; i++) {
+      positions.push([xStart + i * pitch, 0])
+    }
+  } else if (rows > 2 && numPinsPerRow > 2) {
+    let current = 0
+    for (let r = 0; r < rows && current < numberOfPins; r++) {
+      for (let c = 0; c < numPinsPerRow && current < numberOfPins; c++) {
+        positions.push([xStart + c * pitch, r * ySpacing])
+        current++
+      }
+    }
+  } else {
+    let current = 0
+    let top = 0
+    let bottom = rows - 1
+    let left = 0
+    let right = numPinsPerRow - 1
+    while (current < numberOfPins && top <= bottom && left <= right) {
+      for (let row = top; row <= bottom && current < numberOfPins; row++) {
+        positions.push([xStart + left * pitch, row * ySpacing])
+        current++
+      }
+      left++
+      for (let col = left; col <= right && current < numberOfPins; col++) {
+        positions.push([xStart + col * pitch, bottom * ySpacing])
+        current++
+      }
+      bottom--
+      if (left <= right) {
+        for (let row = bottom; row >= top && current < numberOfPins; row--) {
+          positions.push([xStart + right * pitch, row * ySpacing])
+          current++
+        }
+        right--
+      }
+      if (top <= bottom) {
+        for (let col = right; col >= left && current < numberOfPins; col--) {
+          positions.push([xStart + col * pitch, top * ySpacing])
+          current++
+        }
+        top++
+      }
+    }
+  }
+
   const Body = (
     <Colorize color="#1a1a1a">
       <Subtract>
         <Cuboid
           color="#000"
           size={[bodyWidth, bodyDepth, bodyHeight]}
-          center={[0, 0, bodyHeight / 2]}
+          center={[0, (-(rows - 1) * pitch) / 2, bodyHeight / 2]}
         />
-        {Array.from({ length: numberOfPins }, (_, i) =>
+        {positions.map(([x, y], i) =>
           innerDiameter ? (
             <Cylinder
               key={i}
               height={bodyHeight + 0.1}
               radius={innerDiameter / 2}
-              center={[xoff + i * pitch, 0, bodyHeight / 2]}
+              center={[x, y, bodyHeight / 2]}
               color="#222"
             />
           ) : (
             <Cuboid
               key={i}
               size={[gapWidth, gapWidth, bodyHeight]}
-              center={[xoff + i * pitch, 0, bodyHeight / 2]}
+              center={[x, y, bodyHeight / 2]}
             />
           ),
         )}
@@ -50,24 +103,24 @@ export const FemaleHeader = ({
   return (
     <>
       {Body}
-      {Array.from({ length: numberOfPins }, (_, i) => (
+      {positions.map(([x, y], i) => (
         <Colorize color="silver" key={i}>
           <Hull>
             <Cuboid
               color="silver"
               size={[pinThickness, pinThickness, legsLength * 0.9]}
-              center={[xoff + i * pitch, 0, (-legsLength / 2) * 0.9]}
+              center={[x, y, (-legsLength / 2) * 0.9]}
             />
             <Cuboid
               color="silver"
               size={[pinThickness / 1.8, pinThickness / 1.8, legsLength]}
-              center={[xoff + i * pitch, 0, -legsLength / 2]}
+              center={[x, y, -legsLength / 2]}
             />
           </Hull>
           <Cuboid
             color="silver"
             size={[gapWidth, gapWidth, gapWidth * 0.5]}
-            center={[xoff + i * pitch, 0, (gapWidth / 2) * 0.5]}
+            center={[x, y, (gapWidth / 2) * 0.5]}
           />
         </Colorize>
       ))}

--- a/lib/Footprinter3d.tsx
+++ b/lib/Footprinter3d.tsx
@@ -38,6 +38,7 @@ export const Footprinter3d = ({ footprint }: { footprint: string }) => {
     female: boolean
     id: number //innerDiameter
     od: number //outerDiameter
+    rows?: number
   }
   console.log(footprint, fpJson)
 
@@ -94,9 +95,21 @@ export const Footprinter3d = ({ footprint }: { footprint: string }) => {
       )
     case "pinrow":
       if (fpJson.male)
-        return <PinRow numberOfPins={fpJson.num_pins} pitch={fpJson.p} />
+        return (
+          <PinRow
+            numberOfPins={fpJson.num_pins}
+            pitch={fpJson.p}
+            rows={fpJson.rows}
+          />
+        )
       if (fpJson.female)
-        return <FemaleHeader numberOfPins={fpJson.num_pins} pitch={fpJson.p} />
+        return (
+          <FemaleHeader
+            numberOfPins={fpJson.num_pins}
+            pitch={fpJson.p}
+            rows={fpJson.rows}
+          />
+        )
 
     case "cap": {
       switch (fpJson.imperial) {

--- a/lib/PinRow.tsx
+++ b/lib/PinRow.tsx
@@ -1,39 +1,89 @@
-import { Cuboid, Cylinder, Union, HullChain, Colorize, Hull } from "jscad-fiber"
+import { Cuboid, Colorize, Hull } from "jscad-fiber"
 
 export const PinRow = ({
   numberOfPins,
   pitch = 2.54,
   longSidePinLength = 6,
+  rows = 1,
 }: {
   numberOfPins: number
   pitch?: number
   longSidePinLength?: number
+  rows?: number
 }) => {
   const pinThickness = 0.63
   const bodyHeight = 2
-  const bodyWidth = numberOfPins * pitch
+  const numPinsPerRow = Math.ceil(numberOfPins / rows)
+  const bodyWidth = numPinsPerRow * pitch
+  const bodyDepth = (rows - 1) * pitch + pinThickness * 3
   const shortSidePinLength = 3
-  const xoff = -((numberOfPins - 1) / 2) * pitch
+
+  const positions: [number, number][] = []
+  const ySpacing = -pitch
+  const xStart = -((numPinsPerRow - 1) / 2) * pitch
+
+  if (rows === 1) {
+    for (let i = 0; i < numberOfPins; i++) {
+      positions.push([xStart + i * pitch, 0])
+    }
+  } else if (rows > 2 && numPinsPerRow > 2) {
+    let current = 0
+    for (let r = 0; r < rows && current < numberOfPins; r++) {
+      for (let c = 0; c < numPinsPerRow && current < numberOfPins; c++) {
+        positions.push([xStart + c * pitch, r * ySpacing])
+        current++
+      }
+    }
+  } else {
+    let current = 0
+    let top = 0
+    let bottom = rows - 1
+    let left = 0
+    let right = numPinsPerRow - 1
+    while (current < numberOfPins && top <= bottom && left <= right) {
+      for (let row = top; row <= bottom && current < numberOfPins; row++) {
+        positions.push([xStart + left * pitch, row * ySpacing])
+        current++
+      }
+      left++
+      for (let col = left; col <= right && current < numberOfPins; col++) {
+        positions.push([xStart + col * pitch, bottom * ySpacing])
+        current++
+      }
+      bottom--
+      if (left <= right) {
+        for (let row = bottom; row >= top && current < numberOfPins; row--) {
+          positions.push([xStart + right * pitch, row * ySpacing])
+          current++
+        }
+        right--
+      }
+      if (top <= bottom) {
+        for (let col = right; col >= left && current < numberOfPins; col--) {
+          positions.push([xStart + col * pitch, top * ySpacing])
+          current++
+        }
+        top++
+      }
+    }
+  }
+
   return (
     <>
       <Cuboid
         color="#222"
-        size={[bodyWidth, pinThickness * 3, bodyHeight]}
-        center={[0, 0, bodyHeight / 2]}
+        size={[bodyWidth, bodyDepth, bodyHeight]}
+        center={[0, (-(rows - 1) * pitch) / 2, bodyHeight / 2]}
       />
-      {Array.from({ length: numberOfPins }, (_, i) => (
+      {positions.map(([x, y], i) => (
         <>
           {/*Short pins (top) */}
-          <Colorize color="gold">
+          <Colorize color="gold" key={`s${i}`}>
             <Hull>
               <Cuboid
                 color="gold"
                 size={[pinThickness, pinThickness, shortSidePinLength * 0.9]}
-                center={[
-                  xoff + i * pitch,
-                  0,
-                  bodyHeight * 0.9 + bodyHeight / 2,
-                ]}
+                center={[x, y, bodyHeight * 0.9 + bodyHeight / 2]}
               />
               <Cuboid
                 color="gold"
@@ -42,17 +92,17 @@ export const PinRow = ({
                   pinThickness / 1.8,
                   shortSidePinLength,
                 ]}
-                center={[xoff + i * pitch, 0, bodyHeight + bodyHeight / 2]}
+                center={[x, y, bodyHeight + bodyHeight / 2]}
               />
             </Hull>
           </Colorize>
           {/*Long pins (bottom) */}
-          <Colorize color="gold">
+          <Colorize color="gold" key={`l${i}`}>
             <Hull>
               <Cuboid
                 color="gold"
                 size={[pinThickness, pinThickness, longSidePinLength * 0.9]}
-                center={[xoff + i * pitch, 0, (-longSidePinLength / 2) * 0.9]}
+                center={[x, y, (-longSidePinLength / 2) * 0.9]}
               />
               <Cuboid
                 color="gold"
@@ -61,7 +111,7 @@ export const PinRow = ({
                   pinThickness / 1.8,
                   longSidePinLength,
                 ]}
-                center={[xoff + i * pitch, 0, -longSidePinLength / 2]}
+                center={[x, y, -longSidePinLength / 2]}
               />
             </Hull>
           </Colorize>


### PR DESCRIPTION
## Summary
- add `rows` support to `PinRow` and `FemaleHeader`
- pipe `rows` through `Footprinter3d`
- document multi-row pin headers and example usage
- add example for 2x3 pin header

## Testing
- `bun run format`
- `bun test`

------
https://chatgpt.com/codex/tasks/task_b_6886be02c4ac832ebd2f12d3905c6898