### PR TITLE
Fix: Align SOD-123 diode 3D CAD model with footprint

### DIFF
--- a/lib/sod-123.tsx
+++ b/lib/sod-123.tsx
@@ -9,8 +9,6 @@ export const SOD123 = ({ fullWidth = 3.8, fullLength = 1.6 }) => {
   const leadThickness = 0.15
   const leadHeight = 0.5
   const padContactLength = 0.4
-  const leadYOffset = leadHeight / 1 - 0.4
-  const bodyYOffset = leadHeight / 2 - 0.4
 
   const bodyDistance = (fullWidth - bodyWidth) / 2
 
@@ -21,7 +19,7 @@ export const SOD123 = ({ fullWidth = 3.8, fullLength = 1.6 }) => {
         key={1}
         position={{
           x: -fullWidth / 2 + leadWidth / 2,
-          y: leadYOffset,
+          y: 0,
           z: 0,
         }}
         width={leadWidth}
@@ -37,7 +35,7 @@ export const SOD123 = ({ fullWidth = 3.8, fullLength = 1.6 }) => {
         rotation={Math.PI}
         position={{
           x: fullWidth / 2 - leadWidth / 2,
-          y: leadYOffset,
+          y: 0,
           z: 0,
         }}
         width={leadWidth}
@@ -49,7 +47,7 @@ export const SOD123 = ({ fullWidth = 3.8, fullLength = 1.6 }) => {
 
       {/* Chip Body */}
       <ChipBody
-        center={{ x: 0, y: bodyYOffset, z: 0 }}
+        center={{ x: 0, y: 0, z: 0 }}
         width={bodyWidth}
         length={bodyLength}
         height={bodyHeight}

--- a/lib/sod-123.tsx
+++ b/lib/sod-123.tsx
@@ -9,7 +9,7 @@ export const SOD123 = ({ fullWidth = 3.8, fullLength = 1.6 }) => {
   const leadThickness = 0.15
   const leadHeight = 0.5
   const padContactLength = 0.4
-  const padThikness = leadThickness / 2
+  const padThickness = leadThickness / 2
 
   const bodyDistance = (fullWidth - bodyWidth) / 2
 
@@ -21,7 +21,7 @@ export const SOD123 = ({ fullWidth = 3.8, fullLength = 1.6 }) => {
         position={{
           x: -fullWidth / 2 + leadWidth / 2,
           y: 0,
-          z: padThikness,
+          z: padThickness,
         }}
         width={leadWidth}
         thickness={leadThickness}
@@ -37,7 +37,7 @@ export const SOD123 = ({ fullWidth = 3.8, fullLength = 1.6 }) => {
         position={{
           x: fullWidth / 2 - leadWidth / 2,
           y: 0,
-          z: padThikness,
+          z: padThickness,
         }}
         width={leadWidth}
         thickness={leadThickness}

--- a/lib/sod-123.tsx
+++ b/lib/sod-123.tsx
@@ -9,6 +9,7 @@ export const SOD123 = ({ fullWidth = 3.8, fullLength = 1.6 }) => {
   const leadThickness = 0.15
   const leadHeight = 0.5
   const padContactLength = 0.4
+  const padThikness = leadThickness / 2
 
   const bodyDistance = (fullWidth - bodyWidth) / 2
 
@@ -20,7 +21,7 @@ export const SOD123 = ({ fullWidth = 3.8, fullLength = 1.6 }) => {
         position={{
           x: -fullWidth / 2 + leadWidth / 2,
           y: 0,
-          z: 0,
+          z: padThikness,
         }}
         width={leadWidth}
         thickness={leadThickness}
@@ -36,7 +37,7 @@ export const SOD123 = ({ fullWidth = 3.8, fullLength = 1.6 }) => {
         position={{
           x: fullWidth / 2 - leadWidth / 2,
           y: 0,
-          z: 0,
+          z: padThikness,
         }}
         width={leadWidth}
         thickness={leadThickness}


### PR DESCRIPTION
Fix #116 
/claim #116 
<img width="468" height="673" alt="fix" src="https://github.com/user-attachments/assets/53891162-e568-4f6f-8952-03be2c0a0c00" />
<img width="473" height="558" alt="Screenshot_2025-08-31_22-45-09" src="https://github.com/user-attachments/assets/fd267d7f-ab82-4579-a48d-ca14c3826ac2" />
