### PR TITLE
fix: The `extrudeLinear` operation can have an inverted winding order

### DIFF
--- a/lib/vanilla/render.ts
+++ b/lib/vanilla/render.ts
@@ -141,43 +141,11 @@ function renderNode(
     const height = props?.height ?? props?.h ?? 1
     let g3 = extrusions.extrudeLinear({ height }, base2)
 
-    const subtract = (a: number[], b: number[]): number[] => [
-      a[0]! - b[0]!,
-      a[1]! - b[1]!,
-      a[2]! - b[2]!,
-    ]
-    const cross = (a: number[], b: number[]): number[] => [
-      a[1]! * b[2]! - a[2]! * b[1]!,
-      a[2]! * b[0]! - a[0]! * b[2]!,
-      a[0]! * b[1]! - a[1]! * b[0]!,
-    ]
-    const normalize = (v: number[]): number[] => {
-      const length = Math.hypot(v[0]!, v[1]!, v[2]!)
-      if (!length) return [0, 0, 1]
-      return [v[0]! / length, v[1]! / length, v[2]! / length]
-    }
-
     if (g3.polygons) {
       for (const poly of g3.polygons) {
         if (!poly.plane || !poly.vertices || poly.vertices.length < 3) continue
-
-        const v0 = poly.vertices[0]!
-        const v1 = poly.vertices[1]!
-        const v2 = poly.vertices[2]!
-        const ab = subtract(v1, v0)
-        const ac = subtract(v2, v0)
-        const calculatedNormal = normalize(cross(ab, ac))
-
-        const planeNormal = poly.plane.slice(0, 3)
-        const dotProduct =
-          calculatedNormal[0]! * planeNormal[0]! +
-          calculatedNormal[1]! * planeNormal[1]! +
-          calculatedNormal[2]! * planeNormal[2]!
-
-        // The `extrudeLinear` operation can have an inverted winding order.
-        if (dotProduct > 0) {
-          poly.vertices.reverse()
-        }
+        // The `extrudeLinear` operation have an inverted winding order.
+        poly.vertices.reverse()
       }
     }
 

--- a/lib/vanilla/render.ts
+++ b/lib/vanilla/render.ts
@@ -140,6 +140,47 @@ function renderNode(
       geoms2.length > 1 ? (booleans.union as any)(geoms2) : geoms2[0]
     const height = props?.height ?? props?.h ?? 1
     let g3 = extrusions.extrudeLinear({ height }, base2)
+
+    const subtract = (a: number[], b: number[]): number[] => [
+      a[0]! - b[0]!,
+      a[1]! - b[1]!,
+      a[2]! - b[2]!,
+    ]
+    const cross = (a: number[], b: number[]): number[] => [
+      a[1]! * b[2]! - a[2]! * b[1]!,
+      a[2]! * b[0]! - a[0]! * b[2]!,
+      a[0]! * b[1]! - a[1]! * b[0]!,
+    ]
+    const normalize = (v: number[]): number[] => {
+      const length = Math.hypot(v[0]!, v[1]!, v[2]!)
+      if (!length) return [0, 0, 1]
+      return [v[0]! / length, v[1]! / length, v[2]! / length]
+    }
+
+    if (g3.polygons) {
+      for (const poly of g3.polygons) {
+        if (!poly.plane || !poly.vertices || poly.vertices.length < 3) continue
+
+        const v0 = poly.vertices[0]!
+        const v1 = poly.vertices[1]!
+        const v2 = poly.vertices[2]!
+        const ab = subtract(v1, v0)
+        const ac = subtract(v2, v0)
+        const calculatedNormal = normalize(cross(ab, ac))
+
+        const planeNormal = poly.plane.slice(0, 3)
+        const dotProduct =
+          calculatedNormal[0]! * planeNormal[0]! +
+          calculatedNormal[1]! * planeNormal[1]! +
+          calculatedNormal[2]! * planeNormal[2]!
+
+        // The `extrudeLinear` operation can have an inverted winding order.
+        if (dotProduct > 0) {
+          poly.vertices.reverse()
+        }
+      }
+    }
+
     return [{ geom: g3, color: colorCtx ?? props?.color }]
   }
 


### PR DESCRIPTION
ref: https://github.com/tscircuit/jscad-to-gltf/issues/4


The GLF files generate

<img width="685" height="595" alt="image" src="https://github.com/user-attachments/assets/a4c8a4cd-7ee4-432c-868d-fb9d1853361a" />
<img width="685" height="595" alt="image" src="https://github.com/user-attachments/assets/f1ed6f92-dddb-4ab4-b27b-853612118b2e" />
<img width="685" height="595" alt="image" src="https://github.com/user-attachments/assets/90e55e49-8e30-4347-9085-8d838a499b94" />
<img width="685" height="595" alt="image" src="https://github.com/user-attachments/assets/7289dbcc-055d-42dd-8109-8d45a1916839" />


gltf model link (could not upload github did not allow here in the comment so giving Drive)
https://drive.google.com/file/d/1GTr-ccHnXA26bYYtCLMAwK-qKV1Abg7p/view?usp=sharing
