### PR TITLE
Add tapered hull model to chip bodies

### DIFF
--- a/lib/ChipBody.tsx
+++ b/lib/ChipBody.tsx
@@ -1,4 +1,13 @@
-import { Colorize, Cuboid, Hull, Translate, Union } from "jscad-fiber"
+import {
+  Colorize,
+  Cuboid,
+  Cylinder,
+  Hull,
+  Rotate,
+  Subtract,
+  Translate,
+  Union,
+} from "jscad-fiber"
 export interface ChipBodyProps {
   width: number
   length: number
@@ -19,32 +28,41 @@ export const ChipBody = ({
   const taperInset = Math.min(width, length) * 0.12
   const faceWidth = Math.max(width - taperInset, width * 0.75)
   const faceLength = Math.max(length - taperInset, length * 0.75)
+  const notchRadius = Math.min(width, length) * 0.12
+  const notchCenterZ = height - notchRadius * 0.6
+  const notchCenterY = length / 2 - notchRadius * 0.25
+  const notchLength = faceLength / 8
+  const notchWidth = height / 4
   // TODO the bodies flex a bit outward IRL
   return (
     <Colorize color="#555">
       <Translate offset={center}>
         <Translate offset={{ x: 0, y: 0, z: heightAboveSurface }}>
-          <Union>
-            <Hull>
-              <Translate z={0.005}>
-                <Cuboid size={[faceWidth, faceLength, 0.01]} />
-              </Translate>
-
-              <Translate z={straightHeight}>
-                <Cuboid size={[width, length, 0.01]} />
-              </Translate>
-            </Hull>
-
-            <Hull>
-              <Translate z={straightHeight}>
-                <Cuboid size={[width, length, 0.01]} />
-              </Translate>
-
-              <Translate z={straightHeight + taperHeight}>
-                <Cuboid size={[faceWidth, faceLength, 0.01]} />
-              </Translate>
-            </Hull>
-          </Union>
+          <Subtract>
+            <Union>
+              <Hull>
+                <Translate z={0.005}>
+                  <Cuboid size={[faceWidth, faceLength, 0.01]} />
+                </Translate>
+                <Translate z={straightHeight}>
+                  <Cuboid size={[width, length, 0.01]} />
+                </Translate>
+              </Hull>
+              <Hull>
+                <Translate z={straightHeight}>
+                  <Cuboid size={[width, length, 0.01]} />
+                </Translate>
+                <Translate z={straightHeight + taperHeight}>
+                  <Cuboid size={[faceWidth, faceLength, 0.01]} />
+                </Translate>
+              </Hull>
+            </Union>
+            <Translate offset={{ x: 0, y: notchCenterY, z: height }}>
+              <Rotate rotation={[0, 0, 0]}>
+                <Cylinder radius={notchLength} height={notchWidth} />
+              </Rotate>
+            </Translate>
+          </Subtract>
         </Translate>
       </Translate>
     </Colorize>


### PR DESCRIPTION

<img width="784" height="542" alt="Screenshot_2025-10-10_22-06-12" src="https://github.com/user-attachments/assets/0bb5c589-7c75-4de3-b608-9dd248bed170" />
<img width="590" height="498" alt="Screenshot_2025-10-10_22-05-52" src="https://github.com/user-attachments/assets/0c5e27ad-37c5-405d-a1cc-2ca2c45f139f" />
<img width="923" height="641" alt="Screenshot_2025-10-10_13-31-17" src="https://github.com/user-attachments/assets/b319e5e7-06f7-40d3-b04b-cac643c7c16b" />
<img width="785" height="456" alt="Screenshot_2025-10-10_13-30-55" src="https://github.com/user-attachments/assets/86bf4d46-f812-4e30-b149-2ee0d678420b" />


- add a tapered top surface to the generic chip body using a hull between different footprint sizes
- adjust the chip body construction to combine the straight section with the tapered cap

fix #122 
/claim #122 