### PR TITLE
Add customizable color overrides for A0402 component

### DIFF
--- a/examples/a0402-colors.example.tsx
+++ b/examples/a0402-colors.example.tsx
@@ -10,13 +10,13 @@ export default () => {
       </Translate>
 
       <Translate offset={[0, 0, 0]}>
-        <A0402 color={{ body: "#283046", terminal: "#d4af37" }} />
+        <A0402 color="#283046" />
       </Translate>
 
       <Translate offset={[2, 0, 0]}>
         <A0402
           colors={{
-            body: "#2e3440",
+            center: "#2e3440",
             leftTerminal: "#bf616a",
             rightTerminal: "#88c0d0",
           }}

--- a/lib/A0402.tsx
+++ b/lib/A0402.tsx
@@ -16,8 +16,8 @@ const bodyLength = fullLength - terminatorWidth * 2
 export interface A0402Props {
   /**
    * Backwards-compatible color prop. When provided as a string it controls the
-   * body color, and when provided as an object it can override individual
-   * surfaces.
+   * body color (the dark center section), and when provided as an object it can
+   * override individual surfaces.
    */
   color?: A0402ColorProp
   /**

--- a/lib/a0402-colors.ts
+++ b/lib/a0402-colors.ts
@@ -1,5 +1,10 @@
 export type A0402ColorOverrides = {
   body?: string
+  /**
+   * Alias for the body color to match the common description of the center
+   * dark section of the package.
+   */
+  center?: string
   terminal?: string
   leftTerminal?: string
   rightTerminal?: string
@@ -21,7 +26,10 @@ export const resolveA0402Colors = (
 
   const bodyColor =
     colors?.body ??
-    (typeof color === "string" ? color : colorOverrides.body) ??
+    colors?.center ??
+    (typeof color === "string"
+      ? color
+      : (colorOverrides.body ?? colorOverrides.center)) ??
     "#333"
 
   const terminalFallback = colors?.terminal ?? colorOverrides.terminal ?? "#ccc"

--- a/tests/a0402-colors.test.ts
+++ b/tests/a0402-colors.test.ts
@@ -59,3 +59,18 @@ test("Explicit colors prop wins over color object", () => {
     rightTerminalColor: "#0000ff",
   })
 })
+
+test("A0402 colors accepts center alias for body", () => {
+  const overrides: A0402ColorProp = {
+    center: "#555555",
+    terminal: "#dddddd",
+  }
+
+  const resolved = resolveA0402Colors(overrides)
+
+  expect(resolved).toEqual({
+    bodyColor: "#555555",
+    leftTerminalColor: "#dddddd",
+    rightTerminalColor: "#dddddd",
+  })
+})


### PR DESCRIPTION
## Summary
- allow the A0402 component to accept structured color overrides for the body and terminals
- share the color resolution logic and cover it with unit tests

## Testing
- bun test tests/a0402-colors.test.ts
- bun test tests/snapshots/0402.test.ts
- bunx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68eac39e6e2083308772bca3f4a00749