### PR TITLE
feat: Add color parameter support for footprint components

### DIFF
--- a/examples/footprinter3d/fp-0402-color.example.tsx
+++ b/examples/footprinter3d/fp-0402-color.example.tsx
@@ -1,0 +1,14 @@
+import { JsCadView } from "jscad-fiber"
+import { Footprinter3d } from "lib/Footprinter3d"
+import { ExtrudedPads } from "lib/ExtrudedPads"
+
+const footprint = "0402_color(red)"
+
+export default () => {
+  return (
+    <JsCadView zAxisUp showGrid>
+      <Footprinter3d footprint={footprint} />
+      <ExtrudedPads footprint={footprint} />
+    </JsCadView>
+  )
+}

--- a/lib/Footprinter3d.tsx
+++ b/lib/Footprinter3d.tsx
@@ -144,25 +144,28 @@ export const Footprinter3d = ({ footprint }: { footprint: string }) => {
       return <SOD523 />
   }
 
+  const colorMatch = footprint.match(/_color\(([^)]+)\)/)
+  const color = colorMatch ? colorMatch[1] : undefined
+
   switch (fpJson.imperial) {
     case "0402":
-      return <A0402 />
+      return <A0402 color={color} />
     case "0603":
-      return <A0603 />
+      return <A0603 color={color} />
     case "0805":
-      return <A0805 />
+      return <A0805 color={color} />
     case "0201":
-      return <A0201 />
+      return <A0201 color={color} />
     case "01005":
-      return <A01005 />
+      return <A01005 color={color} />
     case "1206":
-      return <A1206 />
+      return <A1206 color={color} />
     case "1210":
-      return <A1210 />
+      return <A1210 color={color} />
     case "2010":
-      return <A2010 />
+      return <A2010 color={color} />
     case "2512":
-      return <A2512 />
+      return <A2512 color={color} />
   }
   return null
 }


### PR DESCRIPTION
Add color param to footprint string

You can now pass colors to footprint components like this:
- `0402_color(red)`
- `0603_color(#ff0000)`

If no color is given, it falls back to the default. The `cap` case stays the same for now.

Example:
```tsx
// Red 0402
<Footprinter3d footprint="0402_color(red)" />

// Default color
<Footprinter3d footprint="0402" />
```

ref https://github.com/tscircuit/tscircuit/issues/971