### PR TITLE
Fix footprint value for ExtrudedPads in SOT-235 example

### DIFF
--- a/examples/SOT-235.example.tsx
+++ b/examples/SOT-235.example.tsx
@@ -5,7 +5,7 @@ export default () => {
   return (
     <JsCadView zAxisUp showGrid>
       <SOT235 />
-      <ExtrudedPads footprint="sot235" />
+      <ExtrudedPads footprint="sot23_5" />
     </JsCadView>
   )
 }


### PR DESCRIPTION
/fix #163 
In many datasheets, SOT-235 = SOT-23-5 — just a different naming convention.
Found this is footprint repo
https://github.com/tscircuit/footprinter/issues/279#issuecomment-2918160994

## Before
<img width="1920" height="1080" alt="Screenshot_20251027_191505" src="https://github.com/user-attachments/assets/d0084793-3def-4ea9-bf69-b01648770a0c" />

## After
<img width="1953" height="1080" alt="Screenshot_20251027_191720" src="https://github.com/user-attachments/assets/facc38e6-46bd-49fd-8cfe-f24ffb3fce51" />
