### PR TITLE
Fix footprint value in Footprint SOT-235 example

### DIFF
--- a/examples/footprinter3d/fp-sot235.example.tsx
+++ b/examples/footprinter3d/fp-sot235.example.tsx
@@ -3,7 +3,7 @@ import { Footprinter3d } from "lib/Footprinter3d"
 import { ExtrudedPads } from "lib/ExtrudedPads"
 
 export default () => {
-  const footprint = "sot235"
+  const footprint = "sot23_5"
   return (
     <JsCadView zAxisUp>
       <Footprinter3d footprint={footprint} />


### PR DESCRIPTION
Same fix as #164 

## Before
<img width="1920" height="1080" alt="Screenshot_20251028_200422" src="https://github.com/user-attachments/assets/827fc5b5-cc0c-49fc-8da8-509a88388860" />

## After
<img width="1920" height="1080" alt="Screenshot_20251028_200352" src="https://github.com/user-attachments/assets/9db84f5e-47a8-40b4-b835-7bd79d1142f4" />
