### PR TITLE
feat: place copper just below board so pad tops are at z=0 (avoid bod…

### DIFF
--- a/lib/FootprintPad.tsx
+++ b/lib/FootprintPad.tsx
@@ -5,7 +5,7 @@ export const FootprintPad = ({ pad }: { pad: PcbSmtPad }) => {
   if (pad.shape === "rect") {
     return (
       <Colorize color={[255, 0, 0]}>
-        <Translate offset={[pad.x, pad.y, 0]}>
+        <Translate offset={[pad.x, pad.y, -0.005]}>
           <Cuboid size={[pad.width, pad.height, 0.01]} />
         </Translate>
       </Colorize>

--- a/lib/FootprintPlatedHole.tsx
+++ b/lib/FootprintPlatedHole.tsx
@@ -5,7 +5,7 @@ export const FootprintPlatedHole = ({ hole }: { hole: PcbPlatedHole }) => {
   if (hole.shape === "circle") {
     return (
       <Colorize color="#b87333">
-        <Translate offset={[hole.x, hole.y, 0]}>
+        <Translate offset={[hole.x, hole.y, -0.005]}>
           {/* <Rotate axis="z" angle={90}> */}
           <Subtract>
             <Cylinder radius={hole.outer_diameter / 2} height={0.01} />


### PR DESCRIPTION
fixes #152
before 
<img width="682" height="368" alt="image" src="https://github.com/user-attachments/assets/fef4a3ad-4b9e-47ca-ab6a-c4421be51f57" />
<img width="1081" height="791" alt="image" src="https://github.com/user-attachments/assets/20a375e6-1abe-4e7c-acb1-da70dafdba0c" />

After:
<img width="1081" height="940" alt="image" src="https://github.com/user-attachments/assets/5d22a036-c428-43b1-aca9-df08c4dff3a3" />
https://github.com/user-attachments/assets/1d539f39-1d97-46b4-bafb-c7c51ac4f6e4

uses: https://jscad-electronics.vercel.app/?fixture={%22path%22%3A%22examples%2Ffootprinter3d%2Ffp-0402.example.tsx%22}
If you’d like, I can push a tiny clearance (e.g., 0.001) above z=0 for bodies that start exactly at 0, but you may find flush alignment acceptable for visualization.