### PR TITLE
Refactor USB-A and USB-C components to remove useMemo

### DIFF
--- a/lib/USB-A.tsx
+++ b/lib/USB-A.tsx
@@ -1,5 +1,4 @@
 import { Cuboid, Translate, Colorize } from "jscad-fiber"
-import { useMemo } from "react"
 import { DipPinLeg } from "./DualInlinePackage"
 
 interface USB_AProps {
@@ -28,161 +27,151 @@ export const USB_A = ({
   outerColor = "#c4c4c4", // Color of the outer part
 }: USB_AProps) => {
   // Metal casing (plates for sides, top, bottom, etc.)
-  const metalCasing = useMemo(() => {
-    const thickness = metalThickness
-    const positions = [
-      // back side
-      {
-        x: 0,
-        y: outerDepth / 2 - thickness / 2,
-        z: outerHeight / 2 + thickness,
-        size: [outerWidth, thickness, outerHeight],
-      },
-      // top plate
-      {
-        x: 0,
-        y: 0,
-        z: outerHeight - thickness / 2 + thickness,
-        size: [outerWidth, outerDepth, thickness],
-      },
-      // bottom plate
-      {
-        x: 0,
-        y: 0,
-        z: thickness / 2 + thickness,
-        size: [outerWidth + metalThickness, outerDepth, thickness],
-      },
-      // left side
-      {
-        x: -outerWidth / 2,
-        y: 0,
-        z: outerHeight / 2 + thickness,
-        size: [thickness, outerDepth, outerHeight],
-      },
-      // right side
-      {
-        x: outerWidth / 2,
-        y: 0,
-        z: outerHeight / 2 + thickness,
-        size: [thickness, outerDepth, outerHeight],
-      },
-      // front sides
-      {
-        x: outerWidth / 2 + thickness * 0.75,
-        y: -outerDepth / 2 + thickness / 2,
-        z: outerHeight / 2 + thickness,
-        size: [thickness * 1.5, thickness, innerHeight],
-      },
-      {
-        x: -outerWidth / 2 - thickness * 0.75,
-        y: -outerDepth / 2 + thickness / 2,
-        z: outerHeight / 2 + thickness,
-        size: [thickness * 1.5, thickness, innerHeight],
-      },
-      // front top/bottom edges
-      {
-        x: 0,
-        y: -outerDepth / 2 + thickness / 2,
-        z: outerHeight + thickness,
-        size: [outerWidth - metalThickness * 4, thickness, thickness],
-      },
-      {
-        x: 0,
-        y: -outerDepth / 2 + thickness / 2,
-        z: thickness,
-        size: [outerWidth - metalThickness * 4, thickness, thickness],
-      },
-    ]
+  const thickness = metalThickness
+  const positions = [
+    // back side
+    {
+      x: 0,
+      y: outerDepth / 2 - thickness / 2,
+      z: outerHeight / 2 + thickness,
+      size: [outerWidth, thickness, outerHeight],
+    },
+    // top plate
+    {
+      x: 0,
+      y: 0,
+      z: outerHeight - thickness / 2 + thickness,
+      size: [outerWidth, outerDepth, thickness],
+    },
+    // bottom plate
+    {
+      x: 0,
+      y: 0,
+      z: thickness / 2 + thickness,
+      size: [outerWidth + metalThickness, outerDepth, thickness],
+    },
+    // left side
+    {
+      x: -outerWidth / 2,
+      y: 0,
+      z: outerHeight / 2 + thickness,
+      size: [thickness, outerDepth, outerHeight],
+    },
+    // right side
+    {
+      x: outerWidth / 2,
+      y: 0,
+      z: outerHeight / 2 + thickness,
+      size: [thickness, outerDepth, outerHeight],
+    },
+    // front sides
+    {
+      x: outerWidth / 2 + thickness * 0.75,
+      y: -outerDepth / 2 + thickness / 2,
+      z: outerHeight / 2 + thickness,
+      size: [thickness * 1.5, thickness, innerHeight],
+    },
+    {
+      x: -outerWidth / 2 - thickness * 0.75,
+      y: -outerDepth / 2 + thickness / 2,
+      z: outerHeight / 2 + thickness,
+      size: [thickness * 1.5, thickness, innerHeight],
+    },
+    // front top/bottom edges
+    {
+      x: 0,
+      y: -outerDepth / 2 + thickness / 2,
+      z: outerHeight + thickness,
+      size: [outerWidth - metalThickness * 4, thickness, thickness],
+    },
+    {
+      x: 0,
+      y: -outerDepth / 2 + thickness / 2,
+      z: thickness,
+      size: [outerWidth - metalThickness * 4, thickness, thickness],
+    },
+  ]
 
-    return positions.map((pos, index) => (
-      <Colorize key={index} color={outerColor}>
-        <Cuboid
-          size={pos.size as [number, number, number]}
-          center={{ x: pos.x, y: pos.y, z: pos.z }}
-        />
-      </Colorize>
-    ))
-  }, [outerWidth, outerDepth, outerHeight, metalThickness, outerColor])
+  const metalCasing = positions.map((pos, index) => (
+    <Colorize key={index} color={outerColor}>
+      <Cuboid
+        size={pos.size as [number, number, number]}
+        center={{ x: pos.x, y: pos.y, z: pos.z }}
+      />
+    </Colorize>
+  ))
 
   // Plastic insert (inner part)
-  const innerPlastic = useMemo(() => {
-    return (
-      <Translate z={(innerHeight - metalThickness) / 2}>
-        <Colorize color={innerColor}>
-          <Cuboid
-            size={[innerWidth, innerDepth, innerHeight]}
-            center={{ x: 0, y: 0, z: metalThickness * 3 }}
-          />
-        </Colorize>
-      </Translate>
-    )
-  }, [innerWidth, innerHeight, innerDepth, metalThickness, innerColor])
+  const innerPlastic = (
+    <Translate z={(innerHeight - metalThickness) / 2}>
+      <Colorize color={innerColor}>
+        <Cuboid
+          size={[innerWidth, innerDepth, innerHeight]}
+          center={{ x: 0, y: 0, z: metalThickness * 3 }}
+        />
+      </Colorize>
+    </Translate>
+  )
 
   // Pins (outside and inside)
-  const pins = useMemo(() => {
-    // TODO reposition the pins to match footprint
-    const outerPinPositions = [
-      { x: -innerWidth / 3, y: innerDepth / 2, z: 0 },
-      { x: -innerWidth / 9, y: innerDepth / 2, z: 0 },
-      { x: innerWidth / 3, y: innerDepth / 2, z: 0 },
-      { x: innerWidth / 9, y: innerDepth / 2, z: 0 },
-    ]
-    const innerPinPositions = [
-      { x: -innerWidth / 3, y: -0.1, z: innerHeight + metalThickness * 2 },
-      { x: -innerWidth / 9, y: -0.1, z: innerHeight + metalThickness * 2 },
-      { x: innerWidth / 3, y: -0.1, z: innerHeight + metalThickness * 2 },
-      { x: innerWidth / 9, y: -0.1, z: innerHeight + metalThickness * 2 },
-    ]
+  // TODO reposition the pins to match footprint
+  const outerPinPositions = [
+    { x: -innerWidth / 3, y: innerDepth / 2, z: 0 },
+    { x: -innerWidth / 9, y: innerDepth / 2, z: 0 },
+    { x: innerWidth / 3, y: innerDepth / 2, z: 0 },
+    { x: innerWidth / 9, y: innerDepth / 2, z: 0 },
+  ]
+  const innerPinPositions = [
+    { x: -innerWidth / 3, y: -0.1, z: innerHeight + metalThickness * 2 },
+    { x: -innerWidth / 9, y: -0.1, z: innerHeight + metalThickness * 2 },
+    { x: innerWidth / 3, y: -0.1, z: innerHeight + metalThickness * 2 },
+    { x: innerWidth / 9, y: -0.1, z: innerHeight + metalThickness * 2 },
+  ]
 
-    return (
-      <>
-        {outerPinPositions.map((pos, index) => (
-          <Translate key={`outer-${index}`} x={pos.x} y={pos.y} z={pos.z}>
-            <Colorize color="#FFD700">
-              <Cuboid size={[0.8, 0.2, 4]} />
-            </Colorize>
-          </Translate>
-        ))}
-        {innerPinPositions.map((pos, index) => (
-          <Translate key={`inner-${index}`} x={pos.x} y={pos.y} z={pos.z}>
-            <Colorize color="#efbf04">
-              <Cuboid size={[1, innerDepth, 1]} />
-            </Colorize>
-          </Translate>
-        ))}
-      </>
-    )
-  }, [innerWidth, innerDepth, innerHeight, metalThickness])
+  const pins = (
+    <>
+      {outerPinPositions.map((pos, index) => (
+        <Translate key={`outer-${index}`} x={pos.x} y={pos.y} z={pos.z}>
+          <Colorize color="#FFD700">
+            <Cuboid size={[0.8, 0.2, 4]} />
+          </Colorize>
+        </Translate>
+      ))}
+      {innerPinPositions.map((pos, index) => (
+        <Translate key={`inner-${index}`} x={pos.x} y={pos.y} z={pos.z}>
+          <Colorize color="#efbf04">
+            <Cuboid size={[1, innerDepth, 1]} />
+          </Colorize>
+        </Translate>
+      ))}
+    </>
+  )
 
   // Side legs
-  const legs = useMemo(() => {
-    return (
-      <>
-        <DipPinLeg
-          x={-outerWidth / 2}
-          y={outerDepth / 4}
-          z={outerHeight / 2 - 0.55}
-        />
-        <DipPinLeg
-          x={outerWidth / 2}
-          y={outerDepth / 4}
-          z={outerHeight / 2 - 0.55}
-        />
-      </>
-    )
-  }, [outerWidth, outerDepth, outerHeight])
+  const legs = (
+    <>
+      <DipPinLeg
+        x={-outerWidth / 2}
+        y={outerDepth / 4}
+        z={outerHeight / 2 - 0.55}
+      />
+      <DipPinLeg
+        x={outerWidth / 2}
+        y={outerDepth / 4}
+        z={outerHeight / 2 - 0.55}
+      />
+    </>
+  )
 
   // Outer plate
-  const outerPlate = useMemo(() => {
-    const thickness = 0.2
-    return (
-      <Cuboid
-        color={innerColor}
-        center={{ x: 0, y: outerDepth / 4, z: thickness }}
-        size={[outerWidth, innerDepth / 1.6, thickness]}
-      />
-    )
-  }, [innerColor, outerWidth, outerDepth, innerDepth])
+  const outerPlateThickness = 0.2
+  const outerPlate = (
+    <Cuboid
+      color={innerColor}
+      center={{ x: 0, y: outerDepth / 4, z: outerPlateThickness }}
+      size={[outerWidth, innerDepth / 1.6, outerPlateThickness]}
+    />
+  )
 
   return (
     <>

--- a/lib/USB-C.tsx
+++ b/lib/USB-C.tsx
@@ -7,7 +7,6 @@ import {
   Rotate,
   Subtract,
 } from "jscad-fiber"
-import { useMemo } from "react"
 
 interface USB_CProps {
   outerWidth?: number
@@ -55,274 +54,244 @@ export const USB_C = ({
 }: USB_CProps) => {
   // Metal casing (main structure)
   const flatMetalCasing = outerWidth - outerWidth / 5
-  const metalCasing = useMemo(() => {
-    const positions = [
-      // Backplate
-      {
-        plate: "back",
-        x: 0,
-        y: outerDepth / 2 - 0.2,
-        z: outerHeight / 2,
-        size: [flatMetalCasing - 0.1, metalThickness, outerHeight - 0.1],
-      },
-      // Top plate
-      {
-        plate: "top",
-        x: 0,
-        y: 0,
-        z: outerHeight - metalThickness / 2,
-        size: [flatMetalCasing, outerDepth, metalThickness],
-      },
-      // Bottom plate
-      {
-        plate: "bottom",
-        x: 0,
-        y: 0,
-        z: metalThickness / 2,
-        size: [flatMetalCasing, outerDepth, metalThickness],
-      },
-    ]
+  const positions = [
+    // Backplate
+    {
+      plate: "back",
+      x: 0,
+      y: outerDepth / 2 - 0.2,
+      z: outerHeight / 2,
+      size: [flatMetalCasing - 0.1, metalThickness, outerHeight - 0.1],
+    },
+    // Top plate
+    {
+      plate: "top",
+      x: 0,
+      y: 0,
+      z: outerHeight - metalThickness / 2,
+      size: [flatMetalCasing, outerDepth, metalThickness],
+    },
+    // Bottom plate
+    {
+      plate: "bottom",
+      x: 0,
+      y: 0,
+      z: metalThickness / 2,
+      size: [flatMetalCasing, outerDepth, metalThickness],
+    },
+  ]
 
-    return positions.map((pos, index) => (
-      <Colorize
-        key={index}
-        color={pos.plate === "back" ? innerColor : outerColor}
-      >
-        <Cuboid
-          size={pos.size as [number, number, number]}
-          center={{ x: pos.x, y: pos.y, z: pos.z }}
-        />
-      </Colorize>
-    ))
-  }, [outerWidth, outerDepth, outerHeight, metalThickness, outerColor])
-  const curvedSides = useMemo(() => {
-    const positions = [
-      {
-        x: outerWidth / 3 + metalThickness * 2,
-        y: 0,
-        z: outerHeight / 2,
-      },
-      {
-        x: -outerWidth / 3 - metalThickness * 2,
-        y: 0,
-        z: outerHeight / 2,
-      },
-    ]
-    return positions.map((pos, index) => (
-      <Subtract color={outerColor}>
-        <Cylinder
-          rotation={[Math.PI / 2, 0, 0]}
-          key={index}
-          color={outerColor}
-          center={[pos.x, pos.y, pos.z]}
-          radius={outerHeight / 2}
-          height={outerDepth}
-        />
-        <Cylinder
-          rotation={[Math.PI / 2, 0, 0]}
-          key={index + 1}
-          color={"#c4c4c4"}
-          center={[
-            pos.x > 0
-              ? pos.x - metalThickness * 1.5
-              : pos.x + metalThickness * 1.5,
-            pos.y,
-            pos.z,
-          ]}
-          radius={outerHeight / 2 - metalThickness / 3}
-          height={outerDepth}
-        />
-      </Subtract>
-    ))
-  }, [outerWidth, outerDepth, outerHeight, metalThickness, outerColor])
-
-  const backOuterSidePlate = useMemo(() => {
-    const positions = [
-      {
-        center: {
-          x: flatMetalCasing / 2,
-          y: outerDepth / 2 - metalThickness,
-          z: outerHeight / 2,
-        },
-        radius: [flatMetalCasing / 8, metalThickness, outerWidth / 8],
-      },
-      {
-        center: {
-          x: -flatMetalCasing / 2,
-          y: outerDepth / 2 - metalThickness,
-          z: outerHeight / 2,
-        },
-        radius: [flatMetalCasing / 8, metalThickness, outerWidth / 8],
-      },
-    ]
-    return positions.map((pos, index) => (
-      <Ellipsoid
-        key={index}
-        color="#000000"
-        center={pos.center}
-        radius={pos.radius as [number, number, number]}
+  const metalCasing = positions.map((pos, index) => (
+    <Colorize
+      key={index}
+      color={pos.plate === "back" ? innerColor : outerColor}
+    >
+      <Cuboid
+        size={pos.size as [number, number, number]}
+        center={{ x: pos.x, y: pos.y, z: pos.z }}
       />
-    ))
-  }, [outerWidth, outerHeight, outerDepth, metalThickness, outerColor])
+    </Colorize>
+  ))
+  const curvedSidesPositions = [
+    {
+      x: outerWidth / 3 + metalThickness * 2,
+      y: 0,
+      z: outerHeight / 2,
+    },
+    {
+      x: -outerWidth / 3 - metalThickness * 2,
+      y: 0,
+      z: outerHeight / 2,
+    },
+  ]
+  const curvedSides = curvedSidesPositions.map((pos, index) => (
+    <Subtract color={outerColor}>
+      <Cylinder
+        rotation={[Math.PI / 2, 0, 0]}
+        key={index}
+        color={outerColor}
+        center={[pos.x, pos.y, pos.z]}
+        radius={outerHeight / 2}
+        height={outerDepth}
+      />
+      <Cylinder
+        rotation={[Math.PI / 2, 0, 0]}
+        key={index + 1}
+        color={"#c4c4c4"}
+        center={[
+          pos.x > 0
+            ? pos.x - metalThickness * 1.5
+            : pos.x + metalThickness * 1.5,
+          pos.y,
+          pos.z,
+        ]}
+        radius={outerHeight / 2 - metalThickness / 3}
+        height={outerDepth}
+      />
+    </Subtract>
+  ))
+
+  const backOuterSidePlatePositions = [
+    {
+      center: {
+        x: flatMetalCasing / 2,
+        y: outerDepth / 2 - metalThickness,
+        z: outerHeight / 2,
+      },
+      radius: [flatMetalCasing / 8, metalThickness, outerWidth / 8],
+    },
+    {
+      center: {
+        x: -flatMetalCasing / 2,
+        y: outerDepth / 2 - metalThickness,
+        z: outerHeight / 2,
+      },
+      radius: [flatMetalCasing / 8, metalThickness, outerWidth / 8],
+    },
+  ]
+  const backOuterSidePlate = backOuterSidePlatePositions.map((pos, index) => (
+    <Ellipsoid
+      key={index}
+      color="#000000"
+      center={pos.center}
+      radius={pos.radius as [number, number, number]}
+    />
+  ))
 
   // Plastic inner body (smaller to fit the metal casing)
-  const innerPlastic = useMemo(() => {
-    return (
-      <Colorize color={innerColor}>
-        <Cuboid
-          size={[innerWidth, innerDepth, innerHeight]}
-          center={{ x: 0, y: -0.25, z: outerHeight / 2 }}
-        />
-      </Colorize>
-    )
-  }, [innerWidth, innerHeight, innerDepth, metalThickness, innerColor])
+  const innerPlastic = (
+    <Colorize color={innerColor}>
+      <Cuboid
+        size={[innerWidth, innerDepth, innerHeight]}
+        center={{ x: 0, y: -0.25, z: outerHeight / 2 }}
+      />
+    </Colorize>
+  )
 
   // Pins (adjusting position and ensuring proper placement)
-  const innerPins = useMemo(() => {
-    const innerPinsPosition = Array.from(
-      { length: numOfInnerPins },
-      (_, i) => ({
-        x:
-          i < numOfInnerPins / 2
-            ? -innerWidth / 2 +
-              innerPinsWidth / 2 +
-              (i + 1) * (innerPinsWidth + innerPinsGap)
-            : -innerWidth / 2 +
-              innerPinsWidth / 2 +
-              (i - numOfInnerPins / 2 + 1) * (innerPinsWidth + innerPinsGap),
-        y: -0.5,
-        z:
-          i < numOfInnerPins / 2
-            ? outerHeight / 2 - innerPinsHeight - 0.2
-            : outerHeight / 2 + innerPinsHeight + 0.2,
-      }),
-    )
+  const innerPinsPosition = Array.from({ length: numOfInnerPins }, (_, i) => ({
+    x:
+      i < numOfInnerPins / 2
+        ? -innerWidth / 2 +
+          innerPinsWidth / 2 +
+          (i + 1) * (innerPinsWidth + innerPinsGap)
+        : -innerWidth / 2 +
+          innerPinsWidth / 2 +
+          (i - numOfInnerPins / 2 + 1) * (innerPinsWidth + innerPinsGap),
+    y: -0.5,
+    z:
+      i < numOfInnerPins / 2
+        ? outerHeight / 2 - innerPinsHeight - 0.2
+        : outerHeight / 2 + innerPinsHeight + 0.2,
+  }))
 
-    return innerPinsPosition.map((pos, index) => (
-      <Translate key={`pin-${index}`} x={pos.x} y={pos.y} z={pos.z}>
-        <Colorize color={pinColor}>
-          <Cuboid size={[innerPinsWidth, innerPinsDepth, innerPinsHeight]} />
-        </Colorize>
-      </Translate>
-    ))
-  }, [
-    numOfInnerPins,
-    innerPinsWidth,
-    innerPinsDepth,
-    innerPinsHeight,
-    innerPinsGap,
-    pinColor,
-    innerWidth,
-    innerHeight,
-    innerDepth,
-    metalThickness,
-  ])
+  const innerPins = innerPinsPosition.map((pos, index) => (
+    <Translate key={`pin-${index}`} x={pos.x} y={pos.y} z={pos.z}>
+      <Colorize color={pinColor}>
+        <Cuboid size={[innerPinsWidth, innerPinsDepth, innerPinsHeight]} />
+      </Colorize>
+    </Translate>
+  ))
 
   // Side legs
-  const legs = useMemo(() => {
-    const legPositions = [
-      {
-        x: -outerWidth / 2,
-        y: outerDepth / 2,
-        z: 0,
-        width: 1.02,
-        height: 1.1 + outerHeight / 3,
-        thickness: metalThickness,
-      },
-      {
-        x: outerWidth / 2,
-        y: outerDepth / 2,
-        z: 0,
-        width: 1.02,
-        height: 1.1 + outerHeight / 3,
-        thickness: metalThickness,
-      },
-      {
-        x: outerWidth / 2,
-        y: 1.075,
-        z: 0,
-        width: 0.8,
-        height: 1.1 + outerHeight / 3,
-        thickness: metalThickness,
-      },
-      {
-        x: -outerWidth / 2,
-        y: 1.075,
-        z: 0,
-        width: 0.8,
-        height: 1.1 + outerHeight / 3,
-        thickness: metalThickness,
-      },
-    ]
-    return legPositions.map((pos, index) => (
-      <>
-        <Cuboid
-          color={outerColor}
-          key={index}
-          center={{ x: pos.x, y: pos.y - pos.width / 2, z: pos.z }}
-          size={
-            [pos.thickness, pos.width, pos.height] as [number, number, number]
-          }
-        />
-      </>
-    ))
-  }, [outerWidth, outerDepth, outerHeight, sideLegColor])
-  const outerContacts = useMemo(() => {
-    const outerContactPositions = []
-    // Define the x-offsets based on the image increments
-    const xOffsets = [
-      0, // First contact
-      0.305, // Second contact
-      0.61 + 0.205, // Third contact
-      0.915 + 0.205, // Fourth contact
-      1.22 + 0.41, // Fifth contact
-      1.53 + 0.62, // Sixth contact
-      1.84 + 0.83, // Seventh contact
-      2.15 + 1.04, // Eighth contact
-      2.46 + 1.25, // Ninth contact
-      2.77 + 1.46, // Tenth contact
-      3.08 + 1.67, // Eleventh contact
-      3.39 + 1.88, // Twelfth contact
-      3.7 + 2.09, // Thirteenth contact
-      4.01 + 2.09, // Fourteenth contact
-      4.32 + 2.29, // Fifteenth contact
-      4.63 + 2.29, // Sixteenth contact
-    ]
-
-    for (const xOffset of xOffsets) {
-      outerContactPositions.push({
-        x: innerWidth / 2 - xOffset,
-        y: outerDepth / 2,
-        z: 0,
-      })
-    }
-    return outerContactPositions.map((pos, index) => (
+  const legPositions = [
+    {
+      x: -outerWidth / 2,
+      y: outerDepth / 2,
+      z: 0,
+      width: 1.02,
+      height: 1.1 + outerHeight / 3,
+      thickness: metalThickness,
+    },
+    {
+      x: outerWidth / 2,
+      y: outerDepth / 2,
+      z: 0,
+      width: 1.02,
+      height: 1.1 + outerHeight / 3,
+      thickness: metalThickness,
+    },
+    {
+      x: outerWidth / 2,
+      y: 1.075,
+      z: 0,
+      width: 0.8,
+      height: 1.1 + outerHeight / 3,
+      thickness: metalThickness,
+    },
+    {
+      x: -outerWidth / 2,
+      y: 1.075,
+      z: 0,
+      width: 0.8,
+      height: 1.1 + outerHeight / 3,
+      thickness: metalThickness,
+    },
+  ]
+  const legs = legPositions.map((pos, index) => (
+    <>
       <Cuboid
+        color={outerColor}
         key={index}
-        size={[outerPinsWidth, outerPinsDepth, outerPinsThickness]}
-        center={{ x: pos.x, y: pos.y, z: pos.z }}
-        color={pinColor}
+        center={{ x: pos.x, y: pos.y - pos.width / 2, z: pos.z }}
+        size={
+          [pos.thickness, pos.width, pos.height] as [number, number, number]
+        }
       />
-    ))
-  }, [outerWidth, outerDepth, outerHeight, innerColor])
+    </>
+  ))
+  const outerContactPositions = []
+  // Define the x-offsets based on the image increments
+  const xOffsets = [
+    0, // First contact
+    0.305, // Second contact
+    0.61 + 0.205, // Third contact
+    0.915 + 0.205, // Fourth contact
+    1.22 + 0.41, // Fifth contact
+    1.53 + 0.62, // Sixth contact
+    1.84 + 0.83, // Seventh contact
+    2.15 + 1.04, // Eighth contact
+    2.46 + 1.25, // Ninth contact
+    2.77 + 1.46, // Tenth contact
+    3.08 + 1.67, // Eleventh contact
+    3.39 + 1.88, // Twelfth contact
+    3.7 + 2.09, // Thirteenth contact
+    4.01 + 2.09, // Fourteenth contact
+    4.32 + 2.29, // Fifteenth contact
+    4.63 + 2.29, // Sixteenth contact
+  ]
 
-  const cylinderPins = useMemo(() => {
-    const radius = 0.25
-    const height = 0.5
-    const positions = [
-      { x: 2.89, y: innerDepth / 2, z: -height / 2 }, //1
-      { x: -2.89, y: innerDepth / 2, z: -height / 2 }, //2
-    ]
-    return positions.map((pos, index) => (
-      <Colorize color={"#c4c4c4"}>
-        <Cylinder
-          center={{ x: pos.x, y: pos.y, z: pos.z }}
-          radius={radius}
-          height={height}
-        />
-      </Colorize>
-    ))
-  }, [innerWidth, innerHeight, innerDepth, metalThickness, innerColor])
+  for (const xOffset of xOffsets) {
+    outerContactPositions.push({
+      x: innerWidth / 2 - xOffset,
+      y: outerDepth / 2,
+      z: 0,
+    })
+  }
+  const outerContacts = outerContactPositions.map((pos, index) => (
+    <Cuboid
+      key={index}
+      size={[outerPinsWidth, outerPinsDepth, outerPinsThickness]}
+      center={{ x: pos.x, y: pos.y, z: pos.z }}
+      color={pinColor}
+    />
+  ))
+
+  const cylinderPinsRadius = 0.25
+  const cylinderPinsHeight = 0.5
+  const cylinderPinsPositions = [
+    { x: 2.89, y: innerDepth / 2, z: -cylinderPinsHeight / 2 }, //1
+    { x: -2.89, y: innerDepth / 2, z: -cylinderPinsHeight / 2 }, //2
+  ]
+  const cylinderPins = cylinderPinsPositions.map((pos, index) => (
+    <Colorize color={"#c4c4c4"}>
+      <Cylinder
+        center={{ x: pos.x, y: pos.y, z: pos.z }}
+        radius={cylinderPinsRadius}
+        height={cylinderPinsHeight}
+      />
+    </Colorize>
+  ))
   return (
     <>
       {metalCasing}


### PR DESCRIPTION
/fix #184 

This PR removes unnecessary useMemo usage from the USB-A and USB-C UI components.

The PR #105 added React 19 which introduces a smarter compiler and improved heuristics for memoization. As a result, many useMemo cases that were previously needed for performance are now either automatically optimized or counter-productive

# Before:

## Prod:
<img width="1920" height="1080" alt="Screenshot_20251101_124458" src="https://github.com/user-attachments/assets/670aecd7-d3a2-4f27-b1c3-1618bd250c88" />

## Dev:
<img width="1920" height="1080" alt="Screenshot_20251101_124613" src="https://github.com/user-attachments/assets/f0ac2da1-e505-4439-b53d-cd43e95e9c4e" />

# After

## Prod:
<img width="1920" height="1080" alt="Screenshot_20251101_125104" src="https://github.com/user-attachments/assets/953eb74c-883d-48e9-89cc-45f2880b5633" />

## Dev:
<img width="1920" height="1080" alt="Screenshot_20251101_124745" src="https://github.com/user-attachments/assets/639f8f31-a0d9-4a69-b0f7-1e1d40f8091b" />

