### PR TITLE
Fix: chip leads not fully inserted into SOT-723 package

### DIFF
--- a/lib/SOT-723.tsx
+++ b/lib/SOT-723.tsx
@@ -32,7 +32,7 @@ export const SOT723 = () => {
       {[1, 2, 3].map((pn) => {
         const { x, y } = getCcwSot723Coords(pn)
         return (
-          <Translate key={`lead-${pn}`} center={[x, y, 0]}>
+          <Translate key={`lead-${pn}`} center={[x, y, 0.05]}>
             <Cuboid
               size={[
                 leadLength,


### PR DESCRIPTION
## After
<img width="662" height="599" alt="Screenshot_2025-11-03_13-18-09" src="https://github.com/user-attachments/assets/7e8e417a-00a0-4306-bc5c-2994748cb57a" />

## Before
<img width="633" height="609" alt="Screenshot_2025-11-03_13-18-47" src="https://github.com/user-attachments/assets/efec3b75-ed39-4fda-9371-07c6aa3507bc" />
