### PR TITLE
Refactor BGA components to remove useMemo

### DIFF
--- a/lib/BGA.tsx
+++ b/lib/BGA.tsx
@@ -1,6 +1,5 @@
 import { Cuboid, Sphere, Translate, Colorize, Rotate } from "jscad-fiber"
 import { fp } from "@tscircuit/footprinter"
-import { useMemo } from "react"
 
 interface BGAProps {
   packageWidth?: number
@@ -31,11 +30,9 @@ export const BGA = ({
   const bodyOffset = standoffHeight + bodyHeight / 2
   const ballOffset = -standoffHeight / 2
 
-  const ballsSoup = useMemo(() => {
-    if (!footprintString) return null
-    const result = fp.string(footprintString)
-    return result.circuitJson()
-  }, [footprintString])
+  const ballsSoup = footprintString
+    ? fp.string(footprintString).circuitJson()
+    : null
 
   return (
     <>


### PR DESCRIPTION
/fix #189

Same fix as #185

This PR removes unnecessary useMemo usage from the BGA UI components.

The PR #105 added React 19 which introduces a smarter compiler and improved heuristics for memoization. As a result, many useMemo cases that were previously needed for performance are now either automatically optimized or counter-productive

# Before:

## Prod:
<img width="1920" height="1080" alt="Screenshot_20251104_010338" src="https://github.com/user-attachments/assets/30cf40d5-f088-43a3-8d12-fe74de6fc435" />


## Dev:
<img width="1920" height="1080" alt="Screenshot_20251104_010206-1" src="https://github.com/user-attachments/assets/ff0609ff-b887-4d7c-85bf-7e94c3273bbe" />


# After

## Prod:
<img width="1920" height="1080" alt="Screenshot_20251104_010848" src="https://github.com/user-attachments/assets/fc175ac9-98f0-491d-ac5e-3546d71dae36" />


## Dev:
<img width="1920" height="1080" alt="Screenshot_20251104_005927" src="https://github.com/user-attachments/assets/c046a4a5-6e39-403a-9162-d54d64177b29" />

