### PR TITLE
Fix: chip body y coordinate for SOT-723 package

### DIFF
--- a/lib/SOT-723.tsx
+++ b/lib/SOT-723.tsx
@@ -22,7 +22,7 @@ export const SOT723 = () => {
   return (
     <>
       <Rotate rotation={[45 * Math.PI, 0, 0]}>
-        <Translate center={[0.475, leadHeight / 2, -0.25]}>
+        <Translate center={[0.475, 0, -0.25]}>
           <Colorize color="grey">
             <Cuboid size={[bodyWidth, bodyLength, bodyHeight]} />
           </Colorize>


### PR DESCRIPTION
## Before

<img width="530" height="461" alt="Screenshot_2025-11-04_18-27-15" src="https://github.com/user-attachments/assets/dbef85de-0cfd-4526-967e-ad841d42bbd4" />

## After

<img width="459" height="481" alt="Screenshot_2025-11-04_18-26-54" src="https://github.com/user-attachments/assets/1f28eba3-4e81-45fd-9897-1bbaef3aca42" />
