### PR TITLE
Fix cad model are intersecting with pads instead of top of pads

### DIFF
--- a/lib/PinRow.tsx
+++ b/lib/PinRow.tsx
@@ -19,7 +19,7 @@ export const PinRow = ({
       <Cuboid
         color="#222"
         size={[bodyWidth, pinThickness * 3, bodyHeight]}
-        center={[0, 0, bodyHeight / 2]}
+        center={[0, 0, bodyHeight / 2 + 0.012]}
       />
       {Array.from({ length: numberOfPins }, (_, i) => (
         <>


### PR DESCRIPTION
## After

<img width="1055" height="561" alt="Screenshot_2025-11-16_19-07-37" src="https://github.com/user-attachments/assets/4c3a92fd-d808-48f9-8218-1ec7935c0305" />

## Before
<img width="1155" height="726" alt="Screenshot_2025-11-16_18-19-35" src="https://github.com/user-attachments/assets/239b5ce7-a327-445f-b5fd-fa7633936d01" />
