### PR TITLE
Renamed Axialcapacitor to RadialCapacitor component and update footprinter dependency

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,11 +1,12 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "jscad-electronics",
       "devDependencies": {
         "@biomejs/biome": "^1.9.3",
-        "@tscircuit/footprinter": "^0.0.268",
+        "@tscircuit/footprinter": "^0.0.281",
         "@types/react": "19",
         "@types/react-dom": "19",
         "@types/three": "^0.179.0",
@@ -22,7 +23,7 @@
       },
       "peerDependencies": {
         "@jscad/modeling": "^2.12.5",
-        "@tscircuit/footprinter": "^0.0.268",
+        "@tscircuit/footprinter": "*",
         "circuit-json": "^0.0.232",
         "jscad-fiber": "^0.0.85",
         "react": "19.1.0",
@@ -165,7 +166,7 @@
 
     "@skidding/launch-editor": ["@skidding/launch-editor@2.2.3", "https://registry.npmmirror.com/@skidding/launch-editor/-/launch-editor-2.2.3.tgz", { "dependencies": { "chalk": "^2.3.0", "shell-quote": "^1.6.1" } }, "sha512-0SuGEsWdulnbryUJ6humogFuuDMWMb4VJyhOc3FGVkibxVdECYDDkGx8VjS/NePZSegNONDIVhCEVZLTv4ycTQ=="],
 
-    "@tscircuit/footprinter": ["@tscircuit/footprinter@0.0.268", "", { "dependencies": { "@tscircuit/mm": "^0.0.8", "zod": "^3.23.8" }, "peerDependencies": { "circuit-json": "*" } }, "sha512-m35nW63eJ/N7sFgsAP9f+39xxU3oHcPjvW1Ohsg65AhlB4PXeZH2yExwjqG7oQwkh/Pt7arGB28I2Fa0ha4Tiw=="],
+    "@tscircuit/footprinter": ["@tscircuit/footprinter@0.0.281", "", { "dependencies": { "@tscircuit/mm": "^0.0.8", "zod": "^3.23.8" }, "peerDependencies": { "circuit-json": "*" } }, "sha512-21vVO6BTJFSuA7hhX5IvmHPqUWgwjs3scDpVV++ACasF+jeqq3G0VhSX0PElX5mWQA70kNdf9X2KHHuBmtS1wQ=="],
 
     "@tscircuit/mm": ["@tscircuit/mm@0.0.8", "https://registry.npmmirror.com/@tscircuit/mm/-/mm-0.0.8.tgz", { "peerDependencies": { "typescript": "^5.0.0" } }, "sha512-nl7nxE7AhARbKuobflI0LUzoir7+wJyvwfPw6bzA/O0Q3YTcH3vBkU/Of+V/fp6ht+AofiCXj7YAH9E446138Q=="],
 

--- a/examples/RadialCapacitor.example.tsx
+++ b/examples/RadialCapacitor.example.tsx
@@ -1,12 +1,12 @@
 import { JsCadView, Translate, Union } from "jscad-fiber"
-import { AxialCapacitor } from "../lib/AxialCapacitor"
+import { RadialCapacitor } from "../lib/RadialCapacitor"
 import { ExtrudedPads } from "../lib/ExtrudedPads"
 
 export default () => {
   return (
     <JsCadView zAxisUp showGrid>
-      <AxialCapacitor pitch={14} variant="vertical" />
-      <ExtrudedPads footprint="axial_p14mm" />
+      <RadialCapacitor pitch={14} variant="vertical" />
+      <ExtrudedPads footprint="radial_p14mm_id1mm" />
     </JsCadView>
   )
 }

--- a/lib/RadialCapacitor.tsx
+++ b/lib/RadialCapacitor.tsx
@@ -1,4 +1,3 @@
-import { mm } from "@tscircuit/mm"
 import { Cylinder, Sphere } from "jscad-fiber"
 
 interface AxialCapacitorProps {
@@ -6,7 +5,7 @@ interface AxialCapacitorProps {
   variant?: string // Make 'variant' optional
 }
 
-export const AxialCapacitor = ({
+export const RadialCapacitor = ({
   pitch = 10,
   variant = "vertical",
 }: AxialCapacitorProps) => {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.3",
-    "@tscircuit/footprinter": "^0.0.268",
+    "@tscircuit/footprinter": "^0.0.281",
     "@types/react": "19",
     "@types/react-dom": "19",
     "@types/three": "^0.179.0",


### PR DESCRIPTION
This pull request refactors the codebase to replace the axial capacitor component with a radial capacitor component and updates related dependencies and references. The main changes include renaming files and components, updating imports, and modifying the footprint used for extruded pads. Additionally, the `@tscircuit/footprinter` dependency is updated to a newer version.

Component and file refactoring:

* Renamed `lib/AxialCapacitor.tsx` to `lib/RadialCapacitor.tsx`, and changed the component from `AxialCapacitor` to `RadialCapacitor`, updating all relevant references and props.
* Renamed `examples/AxialCapacitor.example.tsx` to `examples/RadialCapacitor.example.tsx`, updating the import to use `RadialCapacitor` and changing the footprint for `ExtrudedPads` to match the radial capacitor.

Dependency update:

* Updated the `@tscircuit/footprinter` dependency in `package.json` from version `^0.0.268` to `^0.0.281`.