### PR TITLE
feat: improve SOIC model to look more like a real chip

### DIFF
--- a/lib/SOIC.tsx
+++ b/lib/SOIC.tsx
@@ -22,7 +22,9 @@ export const SOIC = ({
   const leadHeight = 0.8
   const leadBodyOffset = leadLength * 0
   const fullLength = pitch * (sidePinCount - 1) + leadWidth + 0.2
-  const bodyWidthAdjusted = bodyWidth * 0.55
+  // SOIC body width is typically ~60% of the total width between lead tips
+  // to leave space for the leads on each side
+  const bodyWidthAdjusted = bodyWidth * 0.6
 
   return (
     <>
@@ -62,6 +64,18 @@ export const SOIC = ({
         width={bodyWidthAdjusted}
         length={fullLength}
         height={bodyHeight}
+        // Taper the body so top face is slightly narrower than bottom
+        // giving a more realistic 3D chip appearance
+        taperRatio={0.08}
+        faceRatio={0.78}
+        straightHeightRatio={0.5}
+        // Add chamfered edges for realistic look
+        chamferSize={0.04}
+        // Include pin-1 notch at the top center of the chip
+        includeNotch={true}
+        notchRadius={0.15}
+        notchLength={0.35}
+        notchWidth={0.2}
       />
     </>
   )


### PR DESCRIPTION
## Summary

Improves the SOIC 3D model to look more like a real integrated circuit chip, as requested in #122.

### Changes:
- **Tapered body**: Enabled `taperRatio` (0.08) and `faceRatio` (0.78) so the top face is slightly narrower than the bottom, giving a realistic 3D chip appearance
- **Chamfered edges**: Added `chamferSize` (0.04) for realistic rounded corners
- **Pin-1 notch**: Enabled `includeNotch` with appropriate dimensions for SOIC packages, marking pin-1 orientation
- **Better body width ratio**: Changed from 0.55 to 0.6 for more accurate proportion relative to leads

### Before/After:
The model now leverages the existing `ChipBody` capabilities (taper, chamfer, notch) that were already available but not used in the SOIC component.

Closes #122