### PR TITLE
chore: bump circuit-json peer version to ^0.0.426

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "jscad-electronics",
@@ -25,7 +24,7 @@
         "@jscad/modeling": "^2.12.5",
         "@tscircuit/alphabet": "^0.0.24",
         "@tscircuit/footprinter": "*",
-        "circuit-json": "^0.0.232",
+        "circuit-json": "^0.0.426",
         "jscad-fiber": "^0.0.85",
         "react": "19.1.0",
         "react-dom": "19.1.0",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@jscad/modeling": "^2.12.5",
     "@tscircuit/footprinter": "*",
     "@tscircuit/alphabet": "^0.0.24",
-    "circuit-json": "^0.0.232",
+    "circuit-json": "^0.0.426",
     "jscad-fiber": "^0.0.85",
     "react": "19.1.0",
     "react-dom": "19.1.0",


### PR DESCRIPTION
### Motivation
- Bring the `circuit-json` peer dependency up to the latest published release to avoid peer-version mismatches during installs and to align with other packages expecting the newer API.

### Description
- Bumped `circuit-json` peer dependency from `^0.0.232` to `^0.0.426` in `package.json`.
- Updated the corresponding `circuit-json` peer entry in `bun.lock` so the lockfile matches `package.json`.

### Testing
- Ran `bun test`, which reported 6 passing tests and 59 failing tests due to missing `dist/vanilla.js` required by snapshot/vanilla tests, so the test suite did not fully succeed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0c500243388327b8c6c6b10d71643a)