### PR TITLE
Add failing repro for led0603 throwing in getJscadModelForFootprint

### DIFF
--- a/tests/vanilla-led0603.test.ts
+++ b/tests/vanilla-led0603.test.ts
@@ -1,0 +1,14 @@
+import { test, expect } from "bun:test"
+import { importVanilla } from "./fixtures/importVanilla.js"
+import * as jscadModeling from "@jscad/modeling"
+
+// led0603 throws "Could not determine required pad dimensions (p, pw, ph)"
+// because the bundled @tscircuit/footprinter (0.0.354) can't parse imperial
+// size codes for led footprints (fixed upstream in footprinter 0.0.356).
+test.failing("led0603 returns geometries like 0603 does", async () => {
+  const { getJscadModelForFootprint } = await importVanilla()
+  const res = getJscadModelForFootprint("led0603", jscadModeling)
+  expect(res).toBeDefined()
+  expect(Array.isArray(res.geometries)).toBe(true)
+  expect(res.geometries.length).toBeGreaterThan(0)
+})


### PR DESCRIPTION
Failing repro for #300.

`getJscadModelForFootprint("led0603")` throws `Could not determine required pad dimensions (p, pw, ph)` while `"0603"` works — the bundled footprinter 0.0.354 (caret-locked by `^0.0.354`) can't parse imperial size codes for led footprints, so the 3d viewer shows an error tooltip instead of a model:

![led0603 render error](https://raw.githubusercontent.com/technologyet31-create/jscad-electronics/assets/led0603/led0603-before.png)

`test.failing` so this stays green; the fix (#302) bumps footprinter and flips it to `test`, adding the led0603 png snapshot.