### PR TITLE
fix: render chip footprints named by their pads instead of by size

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -4,6 +4,9 @@
   "workspaces": {
     "": {
       "name": "jscad-electronics",
+      "dependencies": {
+        "@tscircuit/mm": "^0.0.8",
+      },
       "devDependencies": {
         "@biomejs/biome": "^1.9.3",
         "@tscircuit/footprinter": "^0.0.400",
@@ -24,7 +27,7 @@
       "peerDependencies": {
         "@jscad/modeling": "^2.12.5",
         "@tscircuit/alphabet": "^0.0.24",
-        "@tscircuit/footprinter": "^0.0.393",
+        "@tscircuit/footprinter": "*",
         "circuit-json": "^0.0.426",
         "jscad-fiber": "^0.0.85",
         "react": "19.1.0",

--- a/lib/Footprinter3d.tsx
+++ b/lib/Footprinter3d.tsx
@@ -60,6 +60,8 @@ import { JSTZH1_5mm } from "./JSTZH1_5mm"
 import { Crystal } from "./Crystal"
 import { FPC } from "./FPC"
 import { SmdPinHeader } from "./SmdPinHeader"
+import { mm } from "@tscircuit/mm"
+import { ParametricChip } from "./ParametricChip"
 import { Led5050 } from "./Led5050"
 import { RJ45 } from "./RJ45"
 
@@ -307,6 +309,10 @@ export const Footprinter3d = ({ footprint }: { footprint: string }) => {
         case "2512":
           return <A2512 color="#856c4d" />
       }
+      // No EIA size to look up: the pads are the only description of the part,
+      // so fall through to the parametric chip below. Without this `break` the
+      // case ran on into `sot235` and a capacitor rendered as a transistor.
+      break
     }
     case "sot235":
       return <SOT235 />
@@ -524,5 +530,34 @@ export const Footprinter3d = ({ footprint }: { footprint: string }) => {
     case "2512":
       return <A2512 color={color} />
   }
+
+  // A chip named by its pads rather than by an EIA size: `res_p0.8656mm_...`
+  // and `cap_p0.8402mm_...` carry no `imperial`, so neither switch above can
+  // match, and both used to end at `return null` -- an empty model, which
+  // downstream renderers drop silently, taking the component off the board.
+  //
+  // Restricted to the two-terminal chip functions on purpose. Plenty of other
+  // footprints carry a `p`, and a pin header is not a chip.
+  if (
+    (fpJson.fn === "res" || fpJson.fn === "cap") &&
+    fpJson.p !== undefined &&
+    fpJson.ph !== undefined
+  ) {
+    // `mm` is the parser footprinter itself uses on these same strings, so the
+    // body agrees with the pads by construction -- including the inch forms
+    // (`res_p0.1in_...`), which footprinter passes through unconverted.
+    const padPitch = mm(fpJson.p)
+    const padHeight = mm(fpJson.ph)
+    if (Number.isFinite(padPitch) && Number.isFinite(padHeight)) {
+      return (
+        <ParametricChip
+          padPitch={padPitch}
+          padHeight={padHeight}
+          color={color ?? (fpJson.fn === "cap" ? "#856c4d" : undefined)}
+        />
+      )
+    }
+  }
+
   return null
 }

--- a/lib/ParametricChip.tsx
+++ b/lib/ParametricChip.tsx
@@ -1,0 +1,67 @@
+import { Cuboid } from "jscad-fiber"
+
+/**
+ * A two-terminal chip body sized from its land pattern.
+ *
+ * Footprinter names a chip either by EIA size (`0402`) or parametrically by the
+ * pads it wants (`res_p0.8656mm_pw0.5657mm_ph0.54mm`). The named sizes have
+ * hand-modelled bodies -- `A0402` and friends -- and keep using them. This is
+ * for the parametric form, which carries no size to look up and until now
+ * rendered nothing at all.
+ *
+ * The pads are the only evidence available, so the body is derived from them:
+ *
+ * - **length** is the pad pitch. A chip's terminations sit centred on its pads,
+ *   so pitch tracks body length closely: across every EIA size from 0201 up it
+ *   is within 10% of the real part (0402: 1.02 vs 1.0mm, 0603: 1.65 vs 1.6mm,
+ *   1206: 2.93 vs 3.2mm).
+ * - **width and height** are the pad height less a fillet allowance. A land
+ *   pattern is drawn wider than the part so solder can wet the ends, by
+ *   5-30% depending on the size; 0.85 is the middle of that range. Chips of
+ *   this class are near-square in section, so the same figure serves for height.
+ *
+ * The result is a *plausible* body, not a datasheet one -- accurate to about
+ * 15% for 0201 and larger, and deliberately over-estimating for 01005, where a
+ * land pattern is proportionally much larger than the part. That is the right
+ * trade for a part that would otherwise be invisible: an approximate body shows
+ * the board is populated and shows what a clearance check has to clear, while
+ * nothing at all silently hides a component.
+ */
+export const ParametricChip = ({
+  padPitch,
+  padHeight,
+  color = "#333",
+}: {
+  /** Centre-to-centre distance between the two pads, mm. */
+  padPitch: number
+  /** Pad extent across the part, mm. */
+  padHeight: number
+  color?: string
+}) => {
+  const fullLength = padPitch
+  const width = padHeight * 0.85
+  const height = width
+  // Matches the 20% proportion the hand-modelled A-series uses.
+  const terminatorWidth = fullLength * 0.2
+  const bodyLength = fullLength - terminatorWidth * 2
+
+  return (
+    <>
+      <Cuboid
+        size={[bodyLength, width, height]}
+        offset={[0, 0, height / 2]}
+        color={color}
+      />
+      <Cuboid
+        size={[terminatorWidth, height, width]}
+        offset={[fullLength / 2 - terminatorWidth / 2, 0, height / 2]}
+        color="#ccc"
+      />
+      <Cuboid
+        size={[terminatorWidth, height, width]}
+        offset={[-fullLength / 2 + terminatorWidth / 2, 0, height / 2]}
+        color="#ccc"
+      />
+    </>
+  )
+}

--- a/package.json
+++ b/package.json
@@ -28,6 +28,9 @@
     "test:vanilla": "bun run build && node tests/vanilla-smoke.mjs",
     "test": "bun test"
   },
+  "dependencies": {
+    "@tscircuit/mm": "^0.0.8"
+  },
   "devDependencies": {
     "@biomejs/biome": "^1.9.3",
     "@tscircuit/footprinter": "^0.0.400",

--- a/tests/parametric-chip-footprints.test.tsx
+++ b/tests/parametric-chip-footprints.test.tsx
@@ -1,0 +1,120 @@
+import { expect, test } from "bun:test"
+import * as jscadModeling from "@jscad/modeling"
+import { createJSCADRenderer } from "jscad-fiber"
+import { Footprinter3d } from "../lib/Footprinter3d"
+
+const renderFootprint = (footprint: string) => {
+  const container: any[] = []
+  const { createJSCADRoot } = createJSCADRenderer(jscadModeling as any)
+  createJSCADRoot(container).render(<Footprinter3d footprint={footprint} />)
+  return container
+}
+
+const boundsOf = (footprint: string) => {
+  const geoms = renderFootprint(footprint)
+  if (geoms.length === 0) return undefined
+  const [min, max] = jscadModeling.measurements.measureAggregateBoundingBox(
+    ...geoms,
+  )
+  return {
+    length: max[0]! - min[0]!,
+    width: max[1]! - min[1]!,
+    height: max[2]! - min[2]!,
+  }
+}
+
+/**
+ * Footprinter names a chip either by EIA size or by the pads it wants. The
+ * parametric form carries no `imperial`, matched no case, and returned null --
+ * an empty model, which renderers drop silently, so every passive authored this
+ * way disappeared from the 3D view with no diagnostic.
+ */
+test.each([
+  "res_p0.8656mm_pw0.5657mm_ph0.54mm",
+  "res_p0.8402mm_pw0.5mm_ph0.54mm",
+  "cap_p0.8402mm_pw0.5mm_ph0.54mm",
+])("%s renders a body instead of nothing", (footprint) => {
+  expect(renderFootprint(footprint).length).toBeGreaterThan(0)
+})
+
+/**
+ * `case "cap"` had no `break`, so a parametric capacitor fell through into
+ * `case "sot235"` and rendered a 3.4 x 2.9 x 1.35mm transistor -- a wrong model
+ * being worse than a missing one, since nothing about it looks wrong.
+ */
+test("a parametric capacitor is a chip, not the SOT-235 it used to fall through to", () => {
+  const bounds = boundsOf("cap_p0.8402mm_pw0.5mm_ph0.54mm")!
+
+  expect(bounds.length).toBeLessThan(2)
+  expect(bounds.width).toBeLessThan(2)
+  // The SOT-235 body it used to produce.
+  expect(bounds).not.toMatchObject({ length: 3.4, width: 2.9, height: 1.35 })
+})
+
+/**
+ * The derived body is an estimate from the land pattern, so its accuracy is
+ * worth stating rather than assuming: within 15% of the real chip for every EIA
+ * size from 0201 up, checked by feeding each size's own land pattern back in.
+ *
+ * 01005 is excluded deliberately -- its land pattern is proportionally far
+ * larger than the part (pitch 0.5mm for a 0.4mm body), so the estimate runs
+ * ~25% over. Over-estimating the smallest chip in the catalogue is harmless;
+ * pretending the estimate is exact would not be.
+ */
+test.each([
+  ["0201", 0.66, 0.4, 0.6, 0.3],
+  ["0402", 1.02, 0.64, 1.0, 0.5],
+  ["0603", 1.65, 0.95, 1.6, 0.8],
+  ["0805", 1.825, 1.4, 2.0, 1.25],
+  ["1206", 2.925, 1.75, 3.2, 1.6],
+  ["1210", 2.925, 2.65, 3.2, 2.5],
+  ["2010", 4.625, 2.65, 5.0, 2.5],
+  ["2512", 5.925, 3.35, 6.35, 3.2],
+] as const)(
+  "a %s land pattern derives a body within 15% of the real part",
+  (_size, padPitch, padHeight, realLength, realWidth) => {
+    const bounds = boundsOf(`res_p${padPitch}mm_pw0.5mm_ph${padHeight}mm`)!
+
+    expect(Math.abs(bounds.length - realLength) / realLength).toBeLessThan(0.15)
+    expect(Math.abs(bounds.width - realWidth) / realWidth).toBeLessThan(0.15)
+  },
+)
+
+/**
+ * Named sizes keep their hand-modelled bodies: this only fills the gap where
+ * there was nothing, and must not start approximating parts that were already
+ * right.
+ */
+test.each([
+  ["0402", 1.0, 0.5],
+  ["0603", 1.6, 0.85],
+  ["1210", 3.2, 2.5],
+])("%s still uses its exact hand-modelled body", (footprint, length, width) => {
+  const bounds = boundsOf(footprint)!
+
+  expect(bounds.length).toBeCloseTo(length)
+  expect(bounds.width).toBeCloseTo(width)
+})
+
+/**
+ * Footprinter accepts inches in the same position and passes them through
+ * unconverted, so the body has to be parsed with the same `mm` the pads were.
+ * A 0.1in pitch is 2.54mm; a naive `parseFloat` would build a 0.1mm chip.
+ */
+test("an inch-parameterised chip is measured in millimetres", () => {
+  const bounds = boundsOf("res_p0.1in_pw0.02in_ph0.05in")!
+
+  expect(bounds.length).toBeCloseTo(2.54)
+  expect(bounds.width).toBeCloseTo(0.05 * 25.4 * 0.85)
+})
+
+/**
+ * The parametric path is keyed on the chip functions, not on the presence of a
+ * pitch: plenty of footprints carry a `p`, and a pin header is not a chip.
+ */
+test("a pin header is not treated as a chip", () => {
+  const bounds = boundsOf("pinrow4")!
+
+  expect(bounds.length).toBeCloseTo(10.16)
+  expect(renderFootprint("pinrow4").length).toBeGreaterThan(3)
+})


### PR DESCRIPTION
Footprinter names a chip either by EIA size (`0402`) or parametrically by
the pads it wants (`res_p0.8656mm_pw0.5657mm_ph0.54mm`). Only the first
form had a 3D model.

`Footprinter3d` has no `case "res"`; named sizes work because a second
switch on `fpJson.imperial` catches them further down. A parametric string
carries no `imperial`, so it matched neither switch and reached
`return null`. An empty model is not an error anywhere downstream --
circuit-json-to-gltf drops such a component silently -- so every passive
authored this way vanished from the 3D view with nothing logged. On the
board this was found on, that was 26 of 36 passives, and every resistor.

`case "cap"` had a worse version of the same gap: no `break`, so a
parametric capacitor fell through into `case "sot235"` and rendered a
3.4 x 2.9 x 1.35mm transistor. A wrong body is worse than a missing one,
because nothing about it looks wrong.

Derive a body from the land pattern when there is no size to look up:

- length is the pad pitch, which tracks body length within 10% across
  every EIA size from 0201 up (0402: 1.02 vs 1.0mm, 0603: 1.65 vs 1.6mm),
- width and height are the pad height less a fillet allowance, since a
  land pattern is drawn 5-30% wider than the part it solders.

Named sizes keep their exact hand-modelled bodies; this only fills the gap
where there was nothing, and the path is keyed on the chip functions
rather than on the presence of a `p`, since a pin header is not a chip.

Also adds `toMm`: footprinter returns `p: 2.54` for a pin header but the
string `"0.8656mm"` for a chip, so a reader that assumes numbers sees
`undefined` for one whole family of footprints.

Tests state the estimate's accuracy rather than assuming it -- each EIA
size's own land pattern fed back in must land within 15% of the real part
-- and pin the fall-through, the untouched named sizes, and the pin header.
