### PR TITLE
fix: render five-pin SOT-23 footprint

### DIFF
--- a/examples/footprinter3d/fp-sot235.example.tsx
+++ b/examples/footprinter3d/fp-sot235.example.tsx
@@ -5,7 +5,7 @@ import { ExtrudedPads } from "lib/ExtrudedPads"
 export default () => {
   const footprint = "sot23_5"
   return (
-    <JsCadView zAxisUp>
+    <JsCadView zAxisUp showGrid>
       <Footprinter3d footprint={footprint} />
       <ExtrudedPads footprint={footprint} />
     </JsCadView>

--- a/lib/Footprinter3d.tsx
+++ b/lib/Footprinter3d.tsx
@@ -317,10 +317,13 @@ export const Footprinter3d = ({ footprint }: { footprint: string }) => {
       break
     }
     case "sot23":
-      if (fpJson.num_pins === 3) return <SOT233P color={color} />
+      switch (fpJson.num_pins) {
+        case 3:
+          return <SOT233P color={color} />
+        case 5:
+          return <SOT235 />
+      }
       break
-    case "sot235":
-      return <SOT235 />
     case "sot457":
       return <SOT457 />
     case "sot223":

--- a/tests/parametric-chip-footprints.test.tsx
+++ b/tests/parametric-chip-footprints.test.tsx
@@ -118,3 +118,12 @@ test("a pin header is not treated as a chip", () => {
   expect(bounds.length).toBeCloseTo(10.16)
   expect(renderFootprint("pinrow4").length).toBeGreaterThan(3)
 })
+
+test("a five-pin SOT-23 footprint renders its body", () => {
+  const bounds = boundsOf("sot23_5")!
+
+  expect(renderFootprint("sot23_5").length).toBeGreaterThan(0)
+  expect(bounds.length).toBeGreaterThan(2.8)
+  expect(bounds.width).toBeGreaterThan(2.5)
+  expect(bounds.height).toBeGreaterThan(1)
+})


### PR DESCRIPTION
## Summary

- Render the five-pin `sot23_5` footprint with the existing SOT-235 3D model.
- Add a regression test for the five-pin SOT-23 model bounds.
- Enable the ground grid in the SOT-23 footprinter fixture.

## Root cause

The footprinter parses `sot23_5` as `fn: "sot23"` with `num_pins: 5`. The 3D dispatcher only handled the three-pin variant, so it returned no body and the viewer showed only the small pads.

## Before
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/fd8d53ee-3d1f-4de0-974d-4cad39c2bc2c" />

## After
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/638d5225-5e4e-452f-9a9b-d8b7b4fcfe4c" />

## Validation

- `bun test tests/parametric-chip-footprints.test.tsx` — 18 passing
- `git diff --check`

The full suite still has unrelated pre-existing snapshot, RJ45, and FPC failures.
