### PR TITLE
Use published @tscircuit/modelprinter package

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "jscad-electronics",
       "dependencies": {
         "@tscircuit/mm": "^0.0.8",
-        "@tscircuit/modelprinter": "github:tscircuit/modelprinter#a14b0f63028a28e82aa968d3231d59d310462236",
+        "@tscircuit/modelprinter": "^0.0.2",
       },
       "devDependencies": {
         "@biomejs/biome": "^1.9.3",
@@ -190,7 +190,7 @@
 
     "@tscircuit/mm": ["@tscircuit/mm@0.0.8", "", { "peerDependencies": { "typescript": "^5.0.0" } }, "sha512-nl7nxE7AhARbKuobflI0LUzoir7+wJyvwfPw6bzA/O0Q3YTcH3vBkU/Of+V/fp6ht+AofiCXj7YAH9E446138Q=="],
 
-    "@tscircuit/modelprinter": ["@tscircuit/modelprinter@github:tscircuit/modelprinter#a14b0f6", { "dependencies": { "@tscircuit/mm": "^0.0.9", "zod": "^4.4.3" } }, "tscircuit-modelprinter-a14b0f6"],
+    "@tscircuit/modelprinter": ["@tscircuit/modelprinter@0.0.2", "", { "dependencies": { "@tscircuit/mm": "^0.0.9", "zod": "^4.4.3" } }, "sha512-BdKG3MVo246PfrbErBvpdJeS4x7NTv0C4BW12Ho7q7sQ8C5zGtWFEdee5w4nY/0jvIY2WEcpJ+yT3uYBQkOeDg=="],
 
     "@tweenjs/tween.js": ["@tweenjs/tween.js@23.1.3", "", {}, "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA=="],
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@tscircuit/mm": "^0.0.8",
-    "@tscircuit/modelprinter": "github:tscircuit/modelprinter#a14b0f63028a28e82aa968d3231d59d310462236"
+    "@tscircuit/modelprinter": "^0.0.2"
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.3",


### PR DESCRIPTION
## Summary

- replace the temporary GitHub SHA dependency with `@tscircuit/modelprinter@^0.0.2`
- lock the npm tarball and integrity hash

`0.0.2` was published by the tokenless GitHub Actions OIDC workflow and includes an npm SLSA provenance attestation.

## Verification

- `bun test` (171 passing)
- `bunx tsc --noEmit`
- `bun run format:check`